### PR TITLE
Fix consecutive imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![FEArmy](./assets/FEA_open_source_sm.png)](https://github.com/orgs/Wolox/teams/front-end-army/members)
 
-this is the [style-lint](https://stylelint.io/) configuration used by [Wolox](https://www.wolox.com.ar/)
+This is the [style-lint](https://stylelint.io/) configuration used by [Wolox](https://www.wolox.com.ar/)

--- a/index.js
+++ b/index.js
@@ -3,10 +3,8 @@
 module.exports = {
   "plugins": [
     "stylelint-scss",
-    "stylelint-no-indistinguishable-colors"
   ],
   "rules": {
-    "plugin/stylelint-no-indistinguishable-colors": true,
     "scss/at-extend-no-missing-placeholder": true,
     "scss/at-import-no-partial-leading-underscore": true,
     "scss/at-import-partial-extension-blacklist": ["scss"],
@@ -26,7 +24,9 @@ module.exports = {
     "scss/selector-no-redundant-nesting-selector": true,
     "scss/no-duplicate-dollar-variables": true,
     "at-rule-blacklist": null,
-    "at-rule-empty-line-before": "always",
+    "at-rule-empty-line-before": ["always", {
+      "except": ["after-same-name"]
+    }],
     "at-rule-name-case": "lower",
     "at-rule-name-newline-after": null,
     "at-rule-name-space-after": "always",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-wolox",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "style-lint configuration used at Wolox",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,6 @@
   "homepage": "https://github.com/Wolox/stylelint-config-wolox#readme",
   "peerDependencies": {
     "stylelint": "^9.8.0",
-    "stylelint-no-indistinguishable-colors": "^1.2.1",
     "stylelint-scss": "^3.4.0"
   }
 }


### PR DESCRIPTION
- Fix issue that marks consecutive imports as errors for not being separated with enter:

```scss
// This was marked as an error
@import 'variables/...';
@import 'variables/...';
```

- Delete 'no-indistinguishable-colors' plugin, I think it's not working correctly since it's saying 2 different colors are the same while they clearly are not. This could be a potential problem for adapting designs.
